### PR TITLE
Added more crossbrowser support

### DIFF
--- a/knockout.persist.js
+++ b/knockout.persist.js
@@ -8,7 +8,7 @@
         var initialValue = target();
 
         // Load existing value from localStorage if set
-        if (key && localStorage.hasOwnProperty(key)) {
+        if (key && localStorage.getItem(key) !== null) {
             try {
                 initialValue = JSON.parse(localStorage.getItem(key));
             } catch (e) {


### PR DESCRIPTION
Using localStorage.hasOwnProperty(key) not working in Internet Explorer 8 and below(I think, not sure about version, but in some old IE, maybe IE 7 and below). Changing it to localStorage.getItem(key) !== null fixes issues in old IEs.
