### PR TITLE
Update knockout.persist.js

### DIFF
--- a/src/knockout.persist.js
+++ b/src/knockout.persist.js
@@ -1,7 +1,7 @@
 ﻿(function(ko) {
 
     // Don't crash on browsers that are missing localStorage
-    if (typeof (localStorage) === "undefined") { return; }
+    if (typeof (localStorage) === "undefined" || !localstorage) { return; }
 
     ko.extenders.persist = function(target, key) {
 


### PR DESCRIPTION
Sometimes users disable localstorage which returns `null` on some browsers. I just added a quick `or` which if localstorage is `null` return so it doesn't crash.
